### PR TITLE
Alter keys of Shopping List Item

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ http://nominatim.openstreetmap.org/search/Healthy%20Living%20Vermont?format=json
 Notes:
 
 * `_id`: Unique identifier for the document. Generated from the following values, separated by colons:
-  * Parent document type (`list`).
-  * [Collision-resistant ID (cuid)](https://usecuid.org/) of the parent document.
   * Document type (`item`).
   * [Collision-resistant ID (cuid)](https://usecuid.org/).
 * `type`: Document type (will always have a value of `item` for a shopping list item).
@@ -266,15 +264,13 @@ Notes:
 * `createdAt`: Date and time at which the document was created. Expressed as a simplified extended ISO format in zero UTC offset (which can be generated in JavaScript with `new Date().toISOString()`).
 * `updatedAt`: Date and time at which the document was last updated. Expressed as a simplified extended ISO format in zero UTC offset.
 
-Here is an example of a [Mango](http://docs.couchdb.org/en/2.1.0/api/database/find.html) / [`pouchdb-find`](https://pouchdb.com/guides/mango-queries.html) / [Cloudant Query](https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html) selector that utilizes the built-in `_all_docs` view to query a shopping list and all of its list items together:
+Here is an example of a [Mango](http://docs.couchdb.org/en/2.1.0/api/database/find.html) / [`pouchdb-find`](https://pouchdb.com/guides/mango-queries.html) / [Cloudant Query](https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html) selector that fetches a single shopping list's items:
 
 ```javascript
 {
   "selector": {
-    "_id": {
-      "$gte": "list:cj6mj1zfj000001n1ugjfkj33",
-      "$lte": "list:cj6mj1zfj000001n1ugjfkj33:\uffff"
-    }
+    "type": "item",
+    "list": "list:cj6mj1zfj000001n1ugjfkj33"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ http://nominatim.openstreetmap.org/search/Healthy%20Living%20Vermont?format=json
 
 ```javascript
 {
-  "_id": "list:cj6mj1zfj000001n1ugjfkj33:item:cj6mn7e36000001p9n14fgk6s",
+  "_id": "item:cj6mn7e36000001p9n14fgk6s",
   "type": "item",
+  "list": "list:cj6mj1zfj000001n1ugjfkj33",
   "version": 1,
   "title": "Mangos",
   "checked": false,
@@ -258,6 +259,7 @@ Notes:
   * Document type (`item`).
   * [Collision-resistant ID (cuid)](https://usecuid.org/).
 * `type`: Document type (will always have a value of `item` for a shopping list item).
+* `list`: The ID of this item's shopping list
 * `version`: Document schema version.
 * `title`: User-generated title for the shopping list item.
 * `checked`: Has this shopping list item been checked off?


### PR DESCRIPTION
I propose that we simplify the key structure for the shopping list item. If we make the `_id` a simple `item:cj6mn7e36000001p9n14fgk6s` value and add a `list` which is the `_id` of the parent shopping list, then we are able to extract the data cleanly with Mango e.g.

```
{
  selector: { 
     type: 'item',
     list: 'list:cj6mj1zfj000001n1ugjfkj33'
   }
}
```

This is much easier to understand than key mangling on the primary index and allows us to sorting by a third value, for instance.