### PR TITLE
Contributor and maintainer template files

### DIFF
--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+## Contributing In General
+
+Our project welcomes external contributions! If you have an itch, please
+feel free to scratch it.
+
+To contribute code or documentation, you can submit a pull request.  A 
+good way to familiarize yourself with the codebase and contribution process is
+to look for and tackle low-hanging fruit in the issue tracker. Before embarking on
+a more ambitious contribution, please raise an issue for discussion.
+
+**We appreciate your effort, and want to avoid a situation where a contribution
+requires extensive rework (by you or by us), sits in the queue for a long time,
+or cannot be accepted at all!**
+
+### Proposing new features
+
+If you would like to implement a new feature, please raise an issue before sending a pull
+request so the feature can be discussed. This is to avoid you spending your
+valuable time working on a feature that the project developers are not willing
+or able to accept into the code base.
+
+### Fixing bugs
+
+If you would like to fix a bug, please raise an issue before sending a pull
+request so it can be discussed. If the fix is trivial or non controversial then
+this is not usually necessary.
+
+### Merge approval
+
+Two project maintainers will need to review and approve your pull request before it
+is merged.  They may request changes or ask questions so keep an eye on your pull
+request while review is in progress.  Maintainers will expect that:
+
+ - tests pass, and new features have accompanying tests (see the project `README` for more information about running tests)
+ - documentation has been updated where appropriate
+ - any coding standards have been followed (see the project `README` for more information about coding standards)
+
+Some or all of these checks may be automated so look out for immediate feedback from the
+CI system on your pull request.
+
+For more details, see the [MAINTAINERS](MAINTAINERS.md) page.
+
+## Developer Setup
+
+Follow the "Run locally" steps in the `README` and you will have a local git repo 
+and test environment, or use "Deploy to Bluemix" and you can use the Bluemix DevOps environment.
+

--- a/templates/MAINTAINERS.md
+++ b/templates/MAINTAINERS.md
@@ -1,0 +1,69 @@
+# Maintainers Guide
+
+This guide is intended for maintainers - anybody with commit access to one or
+more Code Pattern repositories.
+
+## Methodology
+
+This repository does not have a traditional release management cycle, but
+should instead be maintained as as a useful, working, and polished reference at
+all times. While all work can therefore be focused on the master branch, the
+quality of this branch should never be compromised.
+
+The remainder of this document details how to merge pull requests to the
+repositories.
+
+## Merge approval
+
+The project maintainers use LGTM (Looks Good To Me) in comments on the pull
+request to indicate acceptance prior to merging. A change requires LGTMs from
+two project maintainers. If the code is written by a maintainer, the change
+only requires one additional LGTM.
+
+## Reviewing Pull Requests
+
+We recommend reviewing pull requests directly within GitHub. This allows a
+public commentary on changes, providing transparency for all users. When
+providing feedback be civil, courteous, and kind. Disagreement is fine, so long
+as the discourse is carried out politely. If we see a record of uncivil or
+abusive comments, we will revoke your commit privileges and invite you to leave
+the project.
+
+During your review, consider the following points:
+
+### Does the change have positive impact?
+
+Some proposed changes may not represent a positive impact to the project. Ask
+whether or not the change will make understanding the code easier, or if it
+could simply be a personal preference on the part of the author (see
+[bikeshedding](https://en.wiktionary.org/wiki/bikeshedding)).
+
+Pull requests that do not have a clear positive impact should be closed without
+merging.
+
+### Do the changes make sense?
+
+If you do not understand what the changes are or what they accomplish, ask the
+author for clarification. Ask the author to add comments and/or clarify test
+case names to make the intentions clear.
+
+At times, such clarification will reveal that the author may not be using the
+code correctly, or is unaware of features that accommodate their needs. If you
+feel this is the case, work up a code sample that would address the pull
+request for them, and feel free to close the pull request once they confirm.
+
+### Does the change introduce a new feature?
+
+For any given pull request, ask yourself "is this a new feature?" If so, does
+the pull request (or associated issue) contain narrative indicating the need
+for the feature? If not, ask them to provide that information.
+
+Are new unit tests in place that test all new behaviors introduced? If not, do
+not merge the feature until they are! Is documentation in place for the new
+feature? (See the documentation guidelines). If not do not merge the feature
+until it is! Is the feature necessary for general use cases? Try and keep the
+scope of any given component narrow. If a proposed feature does not fit that
+scope, recommend to the user that they maintain the feature on their own, and
+close the request. You may also recommend that they see if the feature gains
+traction among other users, and suggest they re-submit when they can show such
+support.


### PR DESCRIPTION
Fixes #99 .  Added templates for both contributors (based closely on the pouch/polymer one) and maintainers (based closely on the main code patterns one).  Once accepted, these templates will be added or used as a basis for all the offline first shopping list demo projects.